### PR TITLE
Add mergesort

### DIFF
--- a/src/merge_arrays/mergesort.h
+++ b/src/merge_arrays/mergesort.h
@@ -6,9 +6,18 @@
 template <typename T>
 void mergeSort(std::vector<T>& vector)
 {
-    // auto mid =
-    // std::vector<T> lhs(std::begin(vector), std::next(std::begin(vector), vector.size() / 2));
-    // std::vector<T> rhs(std::)
+    if (vector.size() < 2)
+    {
+        return;
+    }
+
+    auto mid = std::next(std::begin(vector), vector.size() / 2);
+    std::vector<T> lhs(std::begin(vector), mid);
+    std::vector<T> rhs(mid, std::end(vector));
+
+    mergeSort(lhs);
+    mergeSort(rhs);
+    vector = merge(lhs, rhs);
 }
 
 #endif /* end of include guard: MERGESORT_H_INCLUDED */

--- a/src/merge_arrays/mergesort.h
+++ b/src/merge_arrays/mergesort.h
@@ -6,6 +6,9 @@
 template <typename T>
 void mergeSort(std::vector<T>& vector)
 {
+    // auto mid =
+    // std::vector<T> lhs(std::begin(vector), std::next(std::begin(vector), vector.size() / 2));
+    // std::vector<T> rhs(std::)
 }
 
 #endif /* end of include guard: MERGESORT_H_INCLUDED */

--- a/src/merge_arrays/mergesort_test.cpp
+++ b/src/merge_arrays/mergesort_test.cpp
@@ -23,3 +23,42 @@ BOOST_AUTO_TEST_CASE(MergeSort_Empty_ReturnsEmpty)
     // Assert
     assertVectorsEqual(c_empty, empty);
 }
+
+BOOST_AUTO_TEST_CASE(MergeSort_OneElement_ReturnsOneElement)
+{
+    // Arrange
+    std::vector<float> oneElement {1.0f};
+    std::vector<float> expected {1.0f};
+
+    // Act
+    mergeSort(oneElement);
+
+    // Assert
+    assertVectorsEqual(expected, oneElement);
+}
+
+BOOST_AUTO_TEST_CASE(MergeSort_TwoSortedElements_ReturnsTwoSortedElements)
+{
+    // Arrange
+    std::vector<float> elements {1.0f, 2.0f};
+    std::vector<float> expected {1.0f, 2.0f};
+
+    // Act
+    mergeSort(elements);
+
+    // Assert
+    assertVectorsEqual(expected, elements);
+}
+
+BOOST_AUTO_TEST_CASE(MergeSort_TwoUnsortedElements_ReturnsTwoSortedElements)
+{
+    // Arrange
+    std::vector<float> elements {2.0f, 1.0f};
+    std::vector<float> expected {1.0f, 2.0f};
+
+    // Act
+    mergeSort(elements);
+
+    // Assert
+    assertVectorsEqual(expected, elements);
+}

--- a/src/merge_arrays/mergesort_test.cpp
+++ b/src/merge_arrays/mergesort_test.cpp
@@ -62,3 +62,42 @@ BOOST_AUTO_TEST_CASE(MergeSort_TwoUnsortedElements_ReturnsTwoSortedElements)
     // Assert
     assertVectorsEqual(expected, elements);
 }
+
+BOOST_AUTO_TEST_CASE(MergeSort_ThreeUnsortedElements_ReturnsThreeSortedElements)
+{
+    // Arrange
+    std::vector<float> elements {3.0f, 2.0f, 1.0f};
+    std::vector<float> expected {1.0f, 2.0f, 3.0f};
+
+    // Act
+    mergeSort(elements);
+
+    // Assert
+    assertVectorsEqual(expected, elements);
+}
+
+BOOST_AUTO_TEST_CASE(MergeSort_FourUnsortedElements_ReturnsFourSortedElements)
+{
+    // Arrange
+    std::vector<float> elements {3.0f, 2.0f, 4.0f, 1.0f};
+    std::vector<float> expected {1.0f, 2.0f, 3.0f, 4.0f};
+
+    // Act
+    mergeSort(elements);
+
+    // Assert
+    assertVectorsEqual(expected, elements);
+}
+
+BOOST_AUTO_TEST_CASE(MergeSort_TenUnsortedElements_ReturnsTenSortedElements)
+{
+    // Arrange
+    std::vector<float> elements {3.0f, 9.0f, 2.0f, 6.0f, 4.0f, 0.0f, 1.0f, 7.0f, 8.0f, 5.0f};
+    std::vector<float> expected {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f};
+
+    // Act
+    mergeSort(elements);
+
+    // Assert
+    assertVectorsEqual(expected, elements);
+}

--- a/src/merge_arrays/meson.build
+++ b/src/merge_arrays/meson.build
@@ -32,6 +32,7 @@ mergesort_unit_test_sources = ['mergesort_test.cpp']
 
 # Add the sources that comprise your executable here.
 array_init_test_exe_sources = ['array_init_test.cpp']
+mergesort_exe_sources = ['ms.cpp']
 
 merge_arrays_tests = executable(
           'merge_arrays_tests',
@@ -54,6 +55,12 @@ mergesort_tests = executable(
 array_init_test_exe = executable(
           'array_init_test',
           sources: array_init_test_exe_sources,
+          include_directories: includes,
+          install: true)
+
+mergesort_exe = executable(
+          'ms',
+          sources: mergesort_exe_sources,
           include_directories: includes,
           install: true)
 

--- a/src/merge_arrays/ms.cpp
+++ b/src/merge_arrays/ms.cpp
@@ -1,25 +1,25 @@
 #include <iostream>
 #include "mergesort.h"
 
-std::vector<float> readStdInForFloats();
-void print(const std::vector<float>& floats);
+std::vector<int> readStdInForInts();
+void print(const std::vector<int>& ints);
 
 int main()
 {
     // Run merge sort on standard input.
-    auto floats = readStdInForFloats();
-    mergeSort(floats);
-    print(floats);
+    auto ints = readStdInForInts();
+    mergeSort(ints);
+    print(ints);
     std::cout << std::endl;
 
     return 0;
 }
 
-std::vector<float> readStdInForFloats()
+std::vector<int> readStdInForInts()
 {
-    std::vector<float> inputToSort;
+    std::vector<int> inputToSort;
 
-    float lastInt;
+    int lastInt;
     while(std::cin >> lastInt)
     {
         inputToSort.push_back(lastInt);
@@ -28,10 +28,10 @@ std::vector<float> readStdInForFloats()
     return inputToSort;
 }
 
-void print(const std::vector<float>& floats)
+void print(const std::vector<int>& ints)
 {
-    for (auto it = std::begin(floats); it != std::end(floats); ++it)
+    for (auto it = std::begin(ints); it != std::end(ints); ++it)
     {
-        std::cout << *it << (std::next(it, 1) == std::end(floats) ? "" : " ");
+        std::cout << *it << (std::next(it, 1) == std::end(ints) ? "" : " ");
     }
 }

--- a/src/merge_arrays/ms.cpp
+++ b/src/merge_arrays/ms.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include "mergesort.h"
+
+std::vector<float> readStdInForFloats();
+void print(const std::vector<float>& floats);
+
+int main()
+{
+    // Run merge sort on standard input.
+    auto floats = readStdInForFloats();
+    mergeSort(floats);
+    print(floats);
+    std::cout << std::endl;
+
+    return 0;
+}
+
+std::vector<float> readStdInForFloats()
+{
+    std::vector<float> inputToSort;
+
+    float lastInt;
+    while(std::cin >> lastInt)
+    {
+        inputToSort.push_back(lastInt);
+    }
+
+    return inputToSort;
+}
+
+void print(const std::vector<float>& floats)
+{
+    for (auto it = std::begin(floats); it != std::end(floats); ++it)
+    {
+        std::cout << *it << (std::next(it, 1) == std::end(floats) ? "" : " ");
+    }
+}


### PR DESCRIPTION
ms is a command line utility that sorts ints read from std in.  The
easiest way to test the utility is to run:

> rit | bs

from the command line.  You can find rit (a program to produce random
integers on std out) in the boost_intro repository.